### PR TITLE
SEO/listing page

### DIFF
--- a/components/listings/show/Body/index.js
+++ b/components/listings/show/Body/index.js
@@ -15,16 +15,17 @@ export default class ListingMainContent extends React.Component {
     const paragraphs = getParagraphs(listing.description)
     const ownerOrAdmin = canEdit(user, listing)
     const listingInfo = ownerOrAdmin
-      ? `${street}, ${street_number} - ${
-          listing.complement
-            ? `${listing.complement}, ${neighborhood}`
-            : neighborhood
-        } `
-      : `${street}, ${neighborhood}`
+      ? `${street}, ${street_number} ${
+          listing.complement ? `- ${listing.complement}` : ''
+        }`
+      : `${street}`
     return (
       <Container>
         <div className="description">
-          <h1 className="street">{listingInfo}</h1>
+          <h1 className="street">
+            {listing.type} na {listingInfo}, {listing.address.neighborhood},{' '}
+            {listing.address.city}
+          </h1>
           <h6>O imóvel</h6>
           {paragraphs &&
             paragraphs.map((paragraph, i) => <p key={i}>{paragraph}</p>)}

--- a/components/listings/show/Head.js
+++ b/components/listings/show/Head.js
@@ -8,11 +8,26 @@ export default class ListingHead extends Component {
     const {listing} = this.props
     const seoImgSrc = mainListingImage(listing.images)
 
+    const description = `Conheça ${
+      listing.matterport_code ? 'com Tour Virtual 3D' : ''
+    } ${listing.type.charAt(listing.type.length - 1)} ${listing.type} na ${
+      listing.address.street
+    }, ${listing.address.neighborhood}, ${listing.address.city} - ${
+      listing.rooms
+    } dormitórios, ${
+      listing.area
+    } metros quadrados, R$ ${listing.price.toLocaleString('pt-BR')},00, ID${
+      listing.id
+    }`
+
     return (
       <Head>
         <title>
-          À venda: {listing.type} - {listing.address.street} -{' '}
-          {listing.address.neighborhood}, {listing.address.city} | EmCasa
+          {listing.type} à venda na {listing.address.street} -
+          {listing.address.neighborhood}, {listing.address.city} - ID{
+            listing.id
+          }{' '}
+          | EmCasa
         </title>
         <link
           rel="stylesheet"

--- a/components/listings/show/Head.js
+++ b/components/listings/show/Head.js
@@ -16,7 +16,7 @@ export default class ListingHead extends Component {
       listing.rooms
     } dormitórios, ${
       listing.area
-    } metros quadrados, R$ ${listing.price.toLocaleString('pt-BR')},00, ID${
+    } metros quadrados, R$ ${listing.price.toLocaleString('pt-BR')},00 - ID${
       listing.id
     }`
 

--- a/components/listings/show/Head.js
+++ b/components/listings/show/Head.js
@@ -40,8 +40,8 @@ export default class ListingHead extends Component {
           type="text/css"
           href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css"
         />
-        <meta name="description" content={listing.description} />
-        <meta property="og:description" content={listing.description} />
+        <meta name="description" content={description} />
+        <meta property="og:description" content={description} />
         <meta property="og:image" content={seoImgSrc} />
         <meta property="og:image:width" content="1024" />
         <meta property="og:image:height" content="768" />

--- a/components/listings/show/Head.js
+++ b/components/listings/show/Head.js
@@ -23,7 +23,7 @@ export default class ListingHead extends Component {
     return (
       <Head>
         <title>
-          {listing.type} à venda na {listing.address.street} -
+          {listing.type} à venda na {listing.address.street} -{' '}
           {listing.address.neighborhood}, {listing.address.city} - ID{
             listing.id
           }{' '}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/1582621411 
- h1 on listing pages now contains: `Apartamento na Avenida General San Martin, 1135 - 401, Leblon, Rio de Janeiro` because we are focusing on the listing not on the address
- Meta description now contains: `Conheça com Tour Virtual 3D o Apartamento na Avenida General San Martin, Leblon, Rio de Janeiro - 3 dormitórios, 154 metros quadrados, R$ 4.100.000,00 - ID24`, if the listing doesn't have matterport_code the title won't have info about the tour.
- Meta tile now contains: `Apartamento à venda na Avenida General San Martin - Leblon, Rio de Janeiro - ID24 | EmCasa`