### PR TITLE
Filter channels with listing property

### DIFF
--- a/pages/user/messages/index.js
+++ b/pages/user/messages/index.js
@@ -28,7 +28,11 @@ class ListingMessages extends Component {
       return <div>Você não possui mensagens.</div>
     }
 
-    return conversations.map(
+    const filteredConversations = conversations.filter(
+      (conversation) => conversation.listing
+    )
+
+    return filteredConversations.map(
       ({id, participant1, participant2, listing, messages}) => (
         <Link
           key={id}


### PR DESCRIPTION
This PR handles the filtering on channels when calling userChannels query.
Some channels are returning the listing property as null what results in an error because we need the listing id of the channel to build the link to the conversation window.
This PR filters to use only the channels that have a valid listing property.