### PR TITLE
Form improvements

### DIFF
--- a/components/listings/new-listing/shared/NavButtons/index.js
+++ b/components/listings/new-listing/shared/NavButtons/index.js
@@ -6,6 +6,26 @@ import Col from '@emcasa/ui-dom/components/Col'
 import Button from '@emcasa/ui-dom/components/Button'
 
 class NavButtons extends PureComponent {
+  constructor(props) {
+    super(props)
+    this.onPressEnter = this.onPressEnter.bind(this)
+  }
+
+  onPressEnter(e) {
+    if (e.key !== 'Enter') return
+    if (this.props.nextEnabled) {
+      this.props.nextStep()
+    }
+  }
+
+  componentDidMount() {
+    document.addEventListener('keypress', this.onPressEnter)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keypress', this.onPressEnter)
+  }
+
   render() {
     return (
       <Row justifyContent="space-between">

--- a/components/listings/new-listing/shared/NavButtons/index.js
+++ b/components/listings/new-listing/shared/NavButtons/index.js
@@ -13,8 +13,8 @@ class NavButtons extends PureComponent {
 
   onPressEnter(e) {
     if (e.key !== 'Enter') return
-    if (this.props.nextEnabled) {
-      this.props.nextStep()
+    if (this.props.submitEnabled) {
+      this.props.onSubmit()
     }
   }
 
@@ -40,8 +40,8 @@ class NavButtons extends PureComponent {
             fluid
             height="tall"
             active={!this.props.loading}
-            disabled={!this.props.nextEnabled || this.props.loading}
-            onClick={this.props.nextStep}>
+            disabled={!this.props.submitEnabled || this.props.loading}
+            onClick={this.props.onSubmit}>
             {this.props.loading ? 'Aguarde...' : 'Avançar'}
           </Button>
         </Col>
@@ -51,15 +51,15 @@ class NavButtons extends PureComponent {
 
   static propTypes = {
     previousStep: PropTypes.func,
-    nextStep: PropTypes.func,
-    nextEnabled: PropTypes.bool.isRequired,
+    onSubmit: PropTypes.func,
+    submitEnabled: PropTypes.bool.isRequired,
     loading: PropTypes.bool
   }
 
   static defaultProps = {
     previousStep: null,
-    nextStep: null,
-    nextEnabled: false,
+    onSubmit: null,
+    submitEnabled: false,
     loading: false
   }
 }

--- a/components/listings/new-listing/steps/AddressInput/index.js
+++ b/components/listings/new-listing/steps/AddressInput/index.js
@@ -155,10 +155,10 @@ class AddressInput extends Component {
                   <View bottom p={4}>
                     <NavButtons
                       previousStep={this.previousStep}
-                      nextStep={() => {
+                      onSubmit={() => {
                         this.nextStep()
                       }}
-                      nextEnabled={isValid}
+                      submitEnabled={isValid}
                       loading={this.state.loading}
                     />
                   </View>

--- a/components/listings/new-listing/steps/Bedrooms/index.js
+++ b/components/listings/new-listing/steps/Bedrooms/index.js
@@ -221,8 +221,8 @@ class Bedrooms extends Component {
                   <View bottom p={4}>
                     <NavButtons
                       previousStep={this.previousStep}
-                      nextStep={this.nextStep}
-                      nextEnabled={isValid}
+                      onSubmit={this.nextStep}
+                      submitEnabled={isValid}
                     />
                   </View>
                 </>

--- a/components/listings/new-listing/steps/Differential/index.js
+++ b/components/listings/new-listing/steps/Differential/index.js
@@ -101,8 +101,8 @@ class Differential extends Component {
                   <View bottom p={4}>
                     <NavButtons
                       previousStep={this.previousStep}
-                      nextStep={this.nextStep}
-                      nextEnabled={isValid}
+                      onSubmit={this.nextStep}
+                      submitEnabled={isValid}
                     />
                   </View>
                 </>

--- a/components/listings/new-listing/steps/Garage/index.js
+++ b/components/listings/new-listing/steps/Garage/index.js
@@ -60,7 +60,7 @@ class Garage extends Component {
   }
 
   validateSpotType(spotType) {
-    if (!spotType) {
+    if (this.state.spots > 0 && !spotType) {
       return "É necessário informar o tipo de vaga"
     }
   }
@@ -112,27 +112,29 @@ class Garage extends Component {
                           </Button.Group>
                         }/>
                     </Row>
-                    <Text color="grey">As vagas estão na Escritura do imóvel ou são do Condomínio?</Text>
-                    <Row mb={4}>
-                      <Col width={1}>
-                        <Field
-                          name="spotType"
-                          validate={this.validateSpotType}
-                          render={() => (
-                            <RadioButton.Group
-                              selectedValue={this.state.spotType}
-                              onChange={(value) => {
-                                setFieldValue('spotType', value)
-                                setFieldTouched('spotType')
-                                this.setState({spotType: value})
-                              }}>
-                              <RadioButton label="Vagas na Escritura" value="deed"/>
-                              <View mb={2}></View>
-                              <RadioButton label="Vagas no Condomínio" value="condominium" />
-                            </RadioButton.Group>
-                          )} />
-                      </Col>
-                    </Row>
+                    {this.state.spots > 0 && <>
+                      <Text color="grey">As vagas estão na Escritura do imóvel ou são do Condomínio?</Text>
+                      <Row mb={4}>
+                        <Col width={1}>
+                          <Field
+                            name="spotType"
+                            validate={this.validateSpotType}
+                            render={() => (
+                              <RadioButton.Group
+                                selectedValue={this.state.spotType}
+                                onChange={(value) => {
+                                  setFieldValue('spotType', value)
+                                  setFieldTouched('spotType')
+                                  this.setState({spotType: value})
+                                }}>
+                                <RadioButton label="Vagas na Escritura" value="deed"/>
+                                <View mb={2}></View>
+                                <RadioButton label="Vagas no Condomínio" value="condominium" />
+                              </RadioButton.Group>
+                            )} />
+                        </Col>
+                      </Row>
+                    </>}
                   </View>
                   <View bottom p={4}>
                     <NavButtons

--- a/components/listings/new-listing/steps/Garage/index.js
+++ b/components/listings/new-listing/steps/Garage/index.js
@@ -82,7 +82,7 @@ class Garage extends Component {
                 spotType: spotType
               }}
               isInitialValid={() => {
-                return !(this.validateSpots(spots) && this.validateSpotType(spotType))
+                return !(this.validateSpots(spots) || this.validateSpotType(spotType))
               }}
               render={({isValid, setFieldTouched, setFieldValue, errors}) => (
                 <>

--- a/components/listings/new-listing/steps/Garage/index.js
+++ b/components/listings/new-listing/steps/Garage/index.js
@@ -139,8 +139,8 @@ class Garage extends Component {
                   <View bottom p={4}>
                     <NavButtons
                       previousStep={this.previousStep}
-                      nextStep={this.nextStep}
-                      nextEnabled={isValid}
+                      onSubmit={this.nextStep}
+                      submitEnabled={isValid}
                     />
                   </View>
                 </>

--- a/components/listings/new-listing/steps/HomeDetails/index.js
+++ b/components/listings/new-listing/steps/HomeDetails/index.js
@@ -241,8 +241,8 @@ class HomeDetails extends Component {
                   <View bottom p={4}>
                     <NavButtons
                       previousStep={this.previousStep}
-                      nextStep={this.nextStep}
-                      nextEnabled={isValid}
+                      onSubmit={this.nextStep}
+                      submitEnabled={isValid}
                     />
                   </View>
                 </>

--- a/components/listings/new-listing/steps/HomeDetails/index.js
+++ b/components/listings/new-listing/steps/HomeDetails/index.js
@@ -96,6 +96,7 @@ class HomeDetails extends Component {
       cond = homeDetails.cond
       iptu = homeDetails.iptu
     }
+    const isHouse = this.state.homeType === HOME_TYPES.house
     return (
       <div ref={this.props.hostRef}>
         <Row justifyContent="center">
@@ -143,7 +144,7 @@ class HomeDetails extends Component {
                         )}/>
                     </Col>
                     <Row mb={4}>
-                      <Col width={1/2} mr={4}>
+                      {!isHouse && <Col width={1/2} mr={4}>
                         <Field
                           name="floor"
                           render={() => (
@@ -161,7 +162,8 @@ class HomeDetails extends Component {
                             />
                           )}/>
                       </Col>
-                      <Col width={1/2} ml={2} mr={4}>
+                      }
+                      <Col width={1/2} ml={isHouse ? 0 : 2} mr={4}>
                         <Field
                           name="area"
                           validate={this.validateArea}
@@ -181,6 +183,7 @@ class HomeDetails extends Component {
                               />
                           )}/>
                       </Col>
+                      {isHouse && <Col width={1/2} ml={2} mr={4}></Col>}
                     </Row>
                     <Row mb={4}>
                       <Col width={1/2} mr={4}>

--- a/components/listings/new-listing/steps/Personal/index.js
+++ b/components/listings/new-listing/steps/Personal/index.js
@@ -202,10 +202,10 @@ class Personal extends Component {
                     <Text color="red">{this.state.error}</Text>
                     <NavButtons
                       previousStep={this.previousStep}
-                      nextStep={() => {
+                      onSubmit={() => {
                         this.estimatePrice()
                       }}
-                      nextEnabled={isValid}
+                      submitEnabled={isValid}
                       loading={this.state.loading}
                     />
                   </View>

--- a/components/listings/new-listing/steps/Phone/index.js
+++ b/components/listings/new-listing/steps/Phone/index.js
@@ -178,8 +178,8 @@ class Phone extends Component {
                   <View bottom p={4}>
                     <NavButtons
                       previousStep={this.previousStep}
-                      nextStep={this.nextStep}
-                      nextEnabled={isValid}
+                      onSubmit={this.nextStep}
+                      submitEnabled={isValid}
                     />
                   </View>
                 </>

--- a/components/listings/new-listing/steps/Pricing/index.js
+++ b/components/listings/new-listing/steps/Pricing/index.js
@@ -220,8 +220,8 @@ class Pricing extends Component {
                   <View bottom p={4}>
                     <NavButtons
                       previousStep={this.previousStep}
-                      nextStep={this.nextStep}
-                      nextEnabled={isValid}
+                      onSubmit={this.nextStep}
+                      submitEnabled={isValid}
                     />
                   </View>
                 </>

--- a/components/listings/new-listing/steps/Pricing/index.js
+++ b/components/listings/new-listing/steps/Pricing/index.js
@@ -57,7 +57,7 @@ class Pricing extends Component {
       this.setState({
         userPrice: pricing.userPrice,
         suggestedPrice: pricing.suggestedPrice,
-        editingPrice: pricing.editingPrice
+        editingPrice: pricing.editingPrice || !pricing.suggestedPrice
       })
     }
   }

--- a/components/listings/new-listing/steps/Summary/index.js
+++ b/components/listings/new-listing/steps/Summary/index.js
@@ -39,7 +39,7 @@ class Summary extends PureComponent {
     const { location, pricing } = this.props
     const { suggestedPrice, userPrice } = pricing
 
-    const formattedSuggestedPrice = suggestedPrice.toLocaleString('pt-BR', currencyStyle)
+    const formattedSuggestedPrice = suggestedPrice ? suggestedPrice.toLocaleString('pt-BR', currencyStyle) : null
     const formattedUserPrice = userPrice.toLocaleString('pt-BR', currencyStyle)
     const address = location.addressData.name
 

--- a/components/listings/new-listing/steps/Summary/index.js
+++ b/components/listings/new-listing/steps/Summary/index.js
@@ -58,10 +58,19 @@ class Summary extends PureComponent {
                 <StaticMap addressData={location.addressData} />
               </Col>
               <Col>
-                <Text color="grey">Seu imóvel da <Text inline fontWeight="bold" color="grey">{address}</Text> foi avaliado por:</Text>
-                <Text fontSize="large" fontWeight="bold" textAlign="center">{formattedSuggestedPrice}</Text>
-                <Text color="grey">Será anunciado por:</Text>
-                <Text fontSize="large" fontWeight="bold" textAlign="center">{formattedUserPrice}</Text>
+                {suggestedPrice ?
+                  <>
+                    <Text color="grey">Seu imóvel da <Text inline fontWeight="bold" color="grey">{address}</Text> foi avaliado por:</Text>
+                    <Text fontSize="large" fontWeight="bold" textAlign="center">{formattedSuggestedPrice}</Text>
+                    <Text color="grey">Será anunciado por:</Text>
+                    <Text fontSize="large" fontWeight="bold" textAlign="center">{formattedUserPrice}</Text>
+                  </>
+                :
+                  <>
+                    <Text color="grey">Seu imóvel da <Text inline fontWeight="bold" color="grey">{address}</Text> será anunciado por:</Text>
+                    <Text fontSize="large" fontWeight="bold" textAlign="center">{formattedUserPrice}</Text>
+                  </>
+                }
                 {this.getServicesText()}
               </Col>
             </View>


### PR DESCRIPTION
- [x] In the Summary step, hide Suggested Price view if no Suggested Price has been calculated.
- [x] Disable `next` button in Pricing step when no Suggested Price has been calculated and no User Price has been input.
- [x] Hide `floor` field when `home` type is selected.
- [x] Hide `spot type` field when no garage spots is selected.
- [x] Allow user to hit `enter` to go to the next step.