### PR TITLE
Listing search and typeahead fixes

### DIFF
--- a/__tests__/components/listings/new-listing/steps/AddressInputMobile/__snapshots__/index.test.js.snap
+++ b/__tests__/components/listings/new-listing/steps/AddressInputMobile/__snapshots__/index.test.js.snap
@@ -91,6 +91,7 @@ exports[`<AddressInput/> should render a clean page 1`] = `
   top: 0;
   right: 0;
   left: 0;
+  bottom: 0;
   z-index: 5;
   background-color: #ffffff;
 }

--- a/components/listings/shared/ListingCard/styles.js
+++ b/components/listings/shared/ListingCard/styles.js
@@ -11,16 +11,16 @@ const MIN_CARD_WIDTH = 300
 const CARD_MARGIN = theme.space[4]
 
 const getCardWidth = () => {
-  const innerWidth = document.documentElement.clientWidth
+  const clientWidth = document.documentElement.clientWidth
   // Two margins (each corner of the document: left of list, right of map)
   const pageMargins = CARD_MARGIN * 2
 
   // Map width to be discounted
   const showMap = shouldShowMap()
-  const mapWidth = showMap ? (innerWidth) * (MAP_WIDTH_PERCENT / 100) : 0
+  const mapWidth = showMap ? (clientWidth) * (MAP_WIDTH_PERCENT / 100) : 0
 
   // Calculated area to fit cards (in one row)
-  const cardsArea = innerWidth - mapWidth - pageMargins + (showMap ? 0 : CARD_MARGIN)
+  const cardsArea = clientWidth - mapWidth - pageMargins + (showMap ? 0 : CARD_MARGIN)
 
   // How many cards, minimum, can fit in this row?
   const cardsPerRow = Math.floor(cardsArea / (MIN_CARD_WIDTH + CARD_MARGIN))

--- a/components/listings/shared/ListingCard/styles.js
+++ b/components/listings/shared/ListingCard/styles.js
@@ -11,16 +11,16 @@ const MIN_CARD_WIDTH = 300
 const CARD_MARGIN = theme.space[4]
 
 const getCardWidth = () => {
-  const containerWidth = window.innerWidth
+  const innerWidth = document.documentElement.clientWidth
   // Two margins (each corner of the document: left of list, right of map)
   const pageMargins = CARD_MARGIN * 2
 
   // Map width to be discounted
   const showMap = shouldShowMap()
-  const mapWidth = showMap ? (containerWidth) * (MAP_WIDTH_PERCENT / 100) : 0
+  const mapWidth = showMap ? (innerWidth) * (MAP_WIDTH_PERCENT / 100) : 0
 
   // Calculated area to fit cards (in one row)
-  const cardsArea = containerWidth - mapWidth - pageMargins + (showMap ? 0 : CARD_MARGIN)
+  const cardsArea = innerWidth - mapWidth - pageMargins + (showMap ? 0 : CARD_MARGIN)
 
   // How many cards, minimum, can fit in this row?
   const cardsPerRow = Math.floor(cardsArea / (MIN_CARD_WIDTH + CARD_MARGIN))

--- a/components/listings/shared/ListingList/index.js
+++ b/components/listings/shared/ListingList/index.js
@@ -277,6 +277,7 @@ class ListingList extends Component {
         fetchPolicy="cache-and-network"
       >
         {({data: {listings}, fetchMore}) => {
+          const hasListings = listings && listings.listings && listings.listings.length > 0
           return (
             <>
               <Title>
@@ -284,7 +285,7 @@ class ListingList extends Component {
               </Title>
               <Container>
                 {this.getListings(listings, fetchMore)}
-                {this.state.renderMap && this.getMap()}
+                {(this.state.renderMap && hasListings) && this.getMap()}
               </Container>
             </>
           )

--- a/components/listings/shared/ListingList/styles.js
+++ b/components/listings/shared/ListingList/styles.js
@@ -26,7 +26,7 @@ const Container = styled(Row)`
 const MapContainer = styled.div`
   position: sticky;
   top: ${HEADER_HEIGHT}px;
-  right: ${themeGet('space.4')}px;
+  margin-right: ${themeGet('space.4')}px;
   overflow: hidden;
   box-sizing: border-box;
   background: white;

--- a/components/listings/shared/Neighborhood/styles.js
+++ b/components/listings/shared/Neighborhood/styles.js
@@ -1,8 +1,5 @@
 import styled from 'styled-components'
 import { themeGet } from 'styled-system'
-import {
-  shouldShowMap
-} from 'components/listings/shared/ListingList/styles'
 
 export const Container = styled.div`
   box-sizing: border-box;
@@ -11,7 +8,7 @@ export const Container = styled.div`
   flex-direction: column;
   border: 1px solid #E0E6ED;
   border-radius: 4px;
-  margin: 0 ${() => shouldShowMap() ? 40 : themeGet('space.4')}px ${themeGet('space.4')}px 0;
+  margin: 0 ${themeGet('space.4')}px ${themeGet('space.4')}px 0;
   padding: 10px;
 `
 

--- a/components/shared/AddressAutoComplete/styles.js
+++ b/components/shared/AddressAutoComplete/styles.js
@@ -51,6 +51,7 @@ const MobieTypeaheadContainer = styled(Row)`
   top: 0;
   right: 0;
   left: 0;
+  bottom: 0;
   z-index: 5;
   background-color: ${themeGet('colors.white')};
 `

--- a/components/shared/NeighborhoodAutoComplete/index.js
+++ b/components/shared/NeighborhoodAutoComplete/index.js
@@ -90,7 +90,7 @@ export default class NeighborhoodAutoComplete extends Component {
           const items = cities.concat(districtsSP).concat(districtsRJ)
           const itemsToSearch = new Fuse(items, {threshold: 0.1 , keys: ['name', 'city', 'state']})
           const results = this.state.input ? itemsToSearch.search(this.state.input) : items
-          return results.filter(d => d.name).slice(0, 5).map((item, index) => {
+          return results.filter(d => d.name).map((item, index) => {
             let url = `/imoveis/${item.stateSlug}/${item.citySlug}`
             if (item.nameSlug) {
               url += `/${slug(item.nameSlug.toLowerCase())}`

--- a/components/shared/NeighborhoodAutoComplete/styles.js
+++ b/components/shared/NeighborhoodAutoComplete/styles.js
@@ -40,6 +40,10 @@ const SearchResultContainer = styled(Row)`
   max-height: 220px;
   overflow-y: scroll;
   overflow-x: hidden;
+
+  @media only screen and (max-width: ${themeGet('breakpoints.0')}) {
+    max-height: 100%;
+  }
 `
 
 const InputContainer = styled(Row)`

--- a/components/shared/NeighborhoodAutoComplete/styles.js
+++ b/components/shared/NeighborhoodAutoComplete/styles.js
@@ -37,6 +37,9 @@ const SearchResultContainer = styled(Row)`
   position: absolute;
   z-index: 1;
   width: ${({width}) => width ? `${width}px` : '100%'};
+  max-height: 220px;
+  overflow-y: scroll;
+  overflow-x: hidden;
 `
 
 const InputContainer = styled(Row)`

--- a/components/shared/Shell/NewHeader/index.js
+++ b/components/shared/Shell/NewHeader/index.js
@@ -91,7 +91,7 @@ export default class Header extends Component {
           <NeighborhoodAutoComplete
             onBackPressed={this.closeMobileSearch}
             onClearInput={() => {}}
-            height={isMobile() ? 'tall' : medium}
+            height={isMobile() ? 'tall' : 'medium'}
           />
         </Col>
       </MobieTypeaheadContainer>


### PR DESCRIPTION
- [x] Show every suggestion in neighborhood search.
- [x] Render full neighborhood list on mobile.
- [x] Prevent page scrolling on mobile typeahead.
- [x] Skip map render when no listings are found.
- [x] Fix card, list and map margins.