### PR TITLE
Fix componentDidCatch error

### DIFF
--- a/pages/listings/new-listing/index.js
+++ b/pages/listings/new-listing/index.js
@@ -142,10 +142,12 @@ class NewListing extends Component {
 
   componentDidCatch(error, errorInfo) {
     Sentry.withScope(scope => {
-      Object.keys(errorInfo).forEach(key => {
-        scope.setExtra(key, errorInfo[key]);
-      });
-      Sentry.captureException(error);
+      if (errorInfo) {
+        Object.keys(errorInfo).forEach(key => {
+          scope.setExtra(key, errorInfo[key])
+        })
+      }
+      Sentry.captureException(error)
     });
   }
 


### PR DESCRIPTION
Add extras only when `errorInfo` is present.