### PR TITLE
Fixing expandedWrapper wrap

### DIFF
--- a/components/listings/shared/ListingFilter/styles.js
+++ b/components/listings/shared/ListingFilter/styles.js
@@ -18,9 +18,8 @@ const Container = styled(Row)`
 `
 
 const expandedWrapper = css`
-  flex-wrap: nowrap;
   overflow: hidden;
-  height: 40px;
+  height: 34px;
 `
 
 const ButtonsWrapper = styled(Row)`


### PR DESCRIPTION
Removing the `flex-wrap: nowrap` and change the `height` to fix the cut elements issue.
![image](https://user-images.githubusercontent.com/320157/50850653-9e4b4800-1361-11e9-8106-354c7016d92a.png)

Fixed: 
![image](https://user-images.githubusercontent.com/320157/50850668-aa370a00-1361-11e9-99c1-e38ca4ce2ed4.png)
