### PR TITLE
Fix/footer links line height

### DIFF
--- a/components/shared/Shell/Footer/styles.js
+++ b/components/shared/Shell/Footer/styles.js
@@ -24,7 +24,7 @@ export const Container = styled(Row)`
 export const TextLink = styled(Text)`
   cursor: pointer;
   color: ${theme.colors.grey};
-  line-height: 0.8em;
+  line-height: 1.2;
   font-size: ${LINK_FONT_SIZE};
   &:hover {
     color: ${theme.colors.pink};

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -173,5 +173,25 @@ const GTM_EVENTS = {
   [LISTING_SEARCH_NEIGHBORHOOD_APPLY]: {
     action: 'User Search Home Page',
     event: 'search_home'
+  },
+  [`${SELLER_ONBOARDING_EVENT_BASE}addressInput`]: {
+    action: 'Seller Onboarding addressInput',
+    event: 'seller_onboarding_addressinput'
+  },
+  [`${SELLER_ONBOARDING_EVENT_BASE}success`]: {
+    action: 'Seller Onboarding Sucess',
+    event: 'seller_onboarding_sucess'
+  },
+  [LISTING_DETAIL_MATTERPORT_OPEN]: {
+    action: 'Listing Detail Matterport Open',
+    event: 'listing_detail_matterport_open'
+  },
+  [LISTING_DETAIL_OPEN_VISIT_FORM]: {
+    action: 'Listing Detail Open Visit Form',
+    event: 'listing_detail_open_visit_form'
+  },
+  [LISTING_DETAIL_SCHEDULE_VISIT]: {
+    action: 'Listing Detail Schedule Visit',
+    event: 'listing_detail_schedule_visit'
   }
 }

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -179,8 +179,8 @@ const GTM_EVENTS = {
     event: 'seller_onboarding_addressinput'
   },
   [`${SELLER_ONBOARDING_EVENT_BASE}success`]: {
-    action: 'Seller Onboarding Sucess',
-    event: 'seller_onboarding_sucess'
+    action: 'Seller Onboarding Success',
+    event: 'seller_onboarding_success'
   },
   [LISTING_DETAIL_MATTERPORT_OPEN]: {
     action: 'Listing Detail Matterport Open',


### PR DESCRIPTION
Change footer links `line-height`

**Problem:** https://emcasa.slack.com/archives/CCJKW2KDX/p1552953511000900
![image](https://user-images.githubusercontent.com/320157/54630744-4a439a80-4a59-11e9-8817-9f4e61f8e3b9.png)



#### Why Unitless Line Heights?
Unitless line heights are recommended due to the fact that child elements will inherit the raw number value, rather than the computed value. With this, child elements can compute their line heights based on their computed font size, rather than inheriting an arbitrary value from a parent that is more likely to need overriding.
https://css-tricks.com/almanac/properties/l/line-height/