### PR TITLE
Fix map pin click and scroll to listing card.

### DIFF
--- a/components/listings/shared/ListingList/index.js
+++ b/components/listings/shared/ListingList/index.js
@@ -8,14 +8,11 @@ import {
 } from 'graphql/listings/queries'
 import differenceBy from 'lodash/differenceBy'
 import map from 'lodash/map'
-import isEmpty from 'lodash/isEmpty'
 import ListingInfiniteScroll from 'components/shared/ListingInfiniteScroll'
 import ListingCard from 'components/listings/shared/ListingCard'
 import Map from 'components/listings/shared/Map'
 import ListingsNotFound from 'components/listings/shared/NotFound'
 import Neighborhood from 'components/listings/shared/Neighborhood'
-import Text from '@emcasa/ui-dom/components/Text'
-import View from '@emcasa/ui-dom/components/View'
 import {
   getTitleTextByFilters,
   getTitleTextByParams

--- a/components/shared/Map/Marker/index.js
+++ b/components/shared/Map/Marker/index.js
@@ -1,4 +1,5 @@
 import {Component} from 'react'
+import PropTypes from 'prop-types'
 import Container from './styles'
 
 export default class MapMarker extends Component {
@@ -19,4 +20,13 @@ export default class MapMarker extends Component {
       </Container>
     )
   }
+}
+
+MapMarker.propTypes = {
+  id: PropTypes.number,
+  lat: PropTypes.string,
+  lng: PropTypes.string,
+  text: PropTypes.string,
+  onSelect: PropTypes.func,
+  highlight: PropTypes.bool
 }

--- a/graphql/listings/queries/index.js
+++ b/graphql/listings/queries/index.js
@@ -57,7 +57,9 @@ export const GET_LISTING = gql`
         city
         lat
         lng
+        postalCode
       }
+      type
     }
   }
 `


### PR DESCRIPTION
When a user clicks a map pin, we write the GET_LISTINGS query result to add to it the listing clicked in case it wasn't there before (from the GET_LISTING query). But since new fields had been added to the GET_LISTINGS query, that were not present in the GET_LISTING one, apollo was refusing the query write due to incompatible fields, resulting in an empty set (listings not found message). This commit adds the required fields to the GET_LISTING query, making both queries results identical.