### PR TITLE
Remove auto focus from name field on login

### DIFF
--- a/components/shared/Common/Buttons/Like/FavoriteLogin/index.js
+++ b/components/shared/Common/Buttons/Like/FavoriteLogin/index.js
@@ -23,9 +23,6 @@ class FavoriteLogin extends Component {
 
   componentDidMount() {
     document.addEventListener('keypress', this.onPressEnter)
-    if (this.nameField && this.nameField.current) {
-      this.nameField.current.focus()
-    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Auto focus is hiding part of the screen on mobile, so we're removing it.