### PR TITLE
Avoid refresh after login

### DIFF
--- a/components/shared/Auth/AccountKit/index.js
+++ b/components/shared/Auth/AccountKit/index.js
@@ -104,6 +104,9 @@ class AccountKit extends Component {
       }
 
       signUpUser(user)
+      dispatchEvent(new CustomEvent('onLogin', {
+        detail: {userInfo}
+      }))
 
       if (skipRedirect) {
         return userInfo
@@ -123,7 +126,6 @@ class AccountKit extends Component {
     const {signIn} = this
     const {children} = this.props
     const {loading} = this.state
-
     return (
       <>
         <Mutation mutation={SIGN_IN_ACCOUNT_KIT}>

--- a/components/shared/Common/Buttons/Like/index.js
+++ b/components/shared/Common/Buttons/Like/index.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { captureException } from '@sentry/browser'
 import get from 'lodash/get'
-import Router from 'next/router'
 import {Mutation} from 'react-apollo'
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import faHeart from '@fortawesome/fontawesome-free-solid/faHeart'
@@ -100,7 +99,6 @@ class LikeButton extends Component {
                 onClose={() => {
                   this.setState({ showSuccess: false })
                   log(LISTING_SAVE_LOGIN_DONE)
-                  Router.replace(location.pathname)
                 }}
               />
             }

--- a/components/shared/Common/Buttons/Like/index.js
+++ b/components/shared/Common/Buttons/Like/index.js
@@ -30,7 +30,7 @@ class LikeButton extends Component {
   state = {
     name: null,
     showLogin: false,
-    showSuccess: false,
+    showSuccess: false
   }
 
   onLoginSuccess = async (userInfo, favoriteListing) => {
@@ -54,7 +54,7 @@ class LikeButton extends Component {
 
       if (response && response.data) {
         log(LISTING_SAVE_LOGIN_SUCCESS)
-        favoriteListing({variables: {id: this.props.listing.id}})
+        favoriteListing({refetchQueries: [{query: GET_USER_LISTINGS_ACTIONS}], variables: {id: this.props.listing.id}})
         this.setState({ showSuccess: true })
       }
     } catch (e) {


### PR DESCRIPTION
- [x] Avoid refresh after login in AccountKit.
- [x] Update user props in next client side.
- [x] Test and remove redirect from other login points.