### PR TITLE
Fix/update streetview position

### DIFF
--- a/components/listings/show/Map/index.js
+++ b/components/listings/show/Map/index.js
@@ -47,10 +47,12 @@ export default class ListingMap extends Component {
   }
 
   componentDidUpdate() {
-    const {isVisible, streetView} = this.props
+    const {listing, isVisible, streetView} = this.props
     const {panorama} = this.state
+    const {lat, lng} = listing.address
 
     if (streetView && panorama) {
+      panorama.setPosition({lat: lat, lng: lng})
       panorama.setVisible(isVisible)
     }
   }


### PR DESCRIPTION
The `google-map-react` keeps the same position when navigate throughout listings.
This PR `setPosition` when `componentDidUpdate`.