### PR TITLE
fix(server): render tag-search page correctly

### DIFF
--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -47,7 +47,7 @@ router.get('/:state/:city/:neighborhood/:extra', (req, res) => {
     actualPage = '/listings/show'
     req.params.streetwithId = req.params.extra
   } else {
-    actualPage = '/listings/'
+    actualPage = '/listings'
     req.params.tag = req.params.extra
   }
 


### PR DESCRIPTION
When running with `NODE_ENV=production` you can't have trailing slash