### PR TITLE
feat(server): replace heroku-ssl-redirect by custom module

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "google-map-react": "1.0.6",
     "graphql": "14.2.1",
     "graphql-tag": "2.10.1",
-    "heroku-ssl-redirect": "0.0.4",
     "humps": "2.0.1",
     "immutability-helper": "2.7.1",
     "intersection-observer": "0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7018,10 +7018,6 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-heroku-ssl-redirect@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/heroku-ssl-redirect/-/heroku-ssl-redirect-0.0.4.tgz#21ba0707aa503b50a412a0946abfaa88ef7d082c"
-
 hey-listen@^1.0.4, hey-listen@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.5.tgz#6d0a3a2f60177f65bc4404d571a00025bf5dc20e"


### PR DESCRIPTION
* Remove `heroku-ssl-redirect` dependency
* Do not force HTTPS on `/ping` endpoint