### PR TITLE
Remove phone formatting before sending to endpoint

### DIFF
--- a/__tests__/utils/text-utils.test.js
+++ b/__tests__/utils/text-utils.test.js
@@ -4,7 +4,8 @@ import {
   roundUpPrice,
   getUrlVars,
   arrayToString,
-  getPhoneMask
+  getPhoneMask,
+  clearPhoneString
 } from 'utils/text-utils'
 
 describe('currency formatting', () => {
@@ -36,6 +37,18 @@ describe('phone mask', () => {
   it('should return a phone mask for a 9 digit number', () => {
     const mask = getPhoneMask('11111111111')
     expect(mask).toEqual(["(", /\d/, /\d/, ")", /\d/, /\d/, /\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/, /\d/])
+  })
+
+  it('should return numbers only from a formatted phone number string', () => {
+    const formattedPhoneNumber = '+55 (11) 22222-3333'
+    const phone = clearPhoneString(formattedPhoneNumber)
+    expect(phone).toBe('+5511222223333')
+  })
+
+  it('should return null when null is passed to the clear phone function', () => {
+    const formattedPhoneNumber = null
+    const phone = clearPhoneString(formattedPhoneNumber)
+    expect(phone).toBe(null)
   })
 })
 

--- a/__tests__/utils/text-utils.test.js
+++ b/__tests__/utils/text-utils.test.js
@@ -5,7 +5,8 @@ import {
   getUrlVars,
   arrayToString,
   getPhoneMask,
-  clearPhoneString
+  clearPhoneString,
+  addInternationalCode
 } from 'utils/text-utils'
 
 describe('currency formatting', () => {
@@ -49,6 +50,24 @@ describe('phone mask', () => {
     const formattedPhoneNumber = null
     const phone = clearPhoneString(formattedPhoneNumber)
     expect(phone).toBe(null)
+  })
+
+  it('should add international code to a phone string', () => {
+    const phone = '11222223333'
+    const result = addInternationalCode(phone)
+    expect(result).toBe('+5511222223333')
+  })
+
+  it('should not add international code when the string already has it', () => {
+    const phone = '+5511222223333'
+    const result = addInternationalCode(phone)
+    expect(result).toBe('+5511222223333')
+  })
+
+  it('should return null when null is passed to addInternationalCode', () => {
+    const phone = null
+    const result = addInternationalCode(phone)
+    expect(result).toBe(null)
   })
 })
 

--- a/services/interest-api.js
+++ b/services/interest-api.js
@@ -1,11 +1,12 @@
 import {post, get} from 'lib/request'
+import {addInternationalCode, clearPhoneString} from 'utils/text-utils'
 
-const buildPayload = (listingId, data) => {
+const buildPayload = (data) => {
   return {
     interest: {
       name: data.name,
       email: data.email,
-      phone: data.phone,
+      phone: addInternationalCode(clearPhoneString(data.phone)),
       message: data.message,
       interest_type_id: data.interest_type_id
     }
@@ -13,8 +14,7 @@ const buildPayload = (listingId, data) => {
 }
 
 export const createInterest = async (listingId, data) => {
-  const payload = buildPayload(listingId, data)
-
+  const payload = buildPayload(data)
   try {
     return await post(`/listings/${listingId}/interests`, payload)
   } catch (error) {

--- a/utils/text-utils.js
+++ b/utils/text-utils.js
@@ -81,6 +81,19 @@ const clearPhoneString = (phoneString) => {
 }
 
 /**
+ * Adds `+55` to the left side of the phone string. Returns the same string if it already has `+55`.
+ *
+ * @param {string} phone
+ */
+const addInternationalCode = (phone) => {
+  const prefix = `+55`
+  if (phone && !phone.startsWith(prefix)) {
+    return `${prefix}${phone}`
+  }
+  return phone
+}
+
+/**
  * Returns a phone mask to be used in Inputs.
  */
 const getPhoneMask = (value) => {
@@ -104,6 +117,7 @@ module.exports = {
   formatRange,
   getPhoneMask,
   clearPhoneString,
+  addInternationalCode,
   PREFIX,
   THOUSANDS_SEPARATOR_SYMBOL
 }

--- a/utils/text-utils.js
+++ b/utils/text-utils.js
@@ -68,8 +68,23 @@ const formatRange = (values, formatFn = (x) => x) => {
   else return `${formatFn(min)} - ${formatFn(max)}`
 }
 
+/**
+ * Clears a phone string to match the format `+5511222223333`.
+ *
+ * @param {string} phoneString
+ */
+const clearPhoneString = (phoneString) => {
+  if (!phoneString) {
+    return phoneString
+  }
+  return phoneString.replace('(', '').replace(')', '').replace(/ /g, '').replace('-', '').replace(/_/g, '')
+}
+
+/**
+ * Returns a phone mask to be used in Inputs.
+ */
 const getPhoneMask = (value) => {
-  const cleanValue = value ? value.replace('(', '').replace(')', '').replace(' ', '').replace('-', '').replace(/_/g, '') : ''
+  const cleanValue = value ? clearPhoneString(value) : ''
   if (cleanValue.length <= 10) {
     return ['(', /\d/, /\d/, ')', /\d/, /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
   } else {
@@ -88,6 +103,7 @@ module.exports = {
   arrayToString,
   formatRange,
   getPhoneMask,
+  clearPhoneString,
   PREFIX,
   THOUSANDS_SEPARATOR_SYMBOL
 }


### PR DESCRIPTION
Removes phone input string format before sending as payload.

Example: `(11)22222-3333` becomes `+5511222223333`.