### PR TITLE
Location API as POST, read first ip of x-forwarded-for

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -77,8 +77,11 @@ const startServer = () => {
         }
       )
 
-      server.get('/location', async (req, res) => {
-        const userIp = req.headers['x-forwarded-for'] || req.connection.remoteAddress
+      server.post('/location', async (req, res) => {
+        let userIp = req.headers['x-forwarded-for'] || req.connection.remoteAddress
+        if (userIp) {
+          userIp = userIp.split(',')[0]
+        }
         const location = geoip.lookup(userIp)
         res.status(200).send({location, userIp})
       })


### PR DESCRIPTION
We're turning the location endpoint into a `POST` so it won't be cached.

Also, `x-forwarded-for` may return more than one IP address (when the request has been chained through more than one server). In these cases, the first IP is the original client address, so that's the one we need.