### PR TITLE
Refactor search to always use state/city

### DIFF
--- a/__tests__/utils/filter-params.test.js
+++ b/__tests__/utils/filter-params.test.js
@@ -28,7 +28,7 @@ describe('listing search filter functions', () => {
     const filters = getNewFiltersFromQuery(query, params)
     expect(filters).toEqual({
       area: {max: 300, min: 35},
-      citiesSlug: ['rio-de-janeiro'],
+      citySlug: 'rio-de-janeiro',
       garageSpots: {max: 2, min: 2},
       neighborhoods: ['botafogo', 'ipanema'],
       neighborhoodsSlugs: ['humaita'],
@@ -63,7 +63,7 @@ describe('listing search filter functions', () => {
         min: 3
       },
       neighborhoods: ['botafogo'],
-      citiesSlugs: ['rio-de-janeiro'],
+      citySlug: 'rio-de-janeiro',
       types: ['Apartamento', 'Cobertura']
     }
     const query = getListingFiltersFromState(filters)
@@ -75,7 +75,8 @@ describe('listing search filter functions', () => {
       minArea: 35,
       minPrice: 250000,
       neighborhoodsSlugs: ['botafogo'],
-      types: ['Apartamento', 'Cobertura']
+      types: ['Apartamento', 'Cobertura'],
+      citiesSlug: ['rio-de-janeiro']
     })
   })
 
@@ -106,10 +107,11 @@ describe('listing search filter functions', () => {
     const asPath = '/imoveis/rj/rio-de-janeiro/humaita/apartamento'
     const location = getLocationFromPath(asPath)
     expect(location).toEqual({
-      city: 'rio-de-janeiro',
-      state: 'rj',
+      citySlug: 'rio-de-janeiro',
+      stateSlug: 'rj',
       filters: {
-        citiesSlug: ['rio-de-janeiro'],
+        citySlug: 'rio-de-janeiro',
+        stateSlug: 'rj',
         types: ['Apartamento'],
         neighborhoods: ['humaita']
       }
@@ -120,10 +122,11 @@ describe('listing search filter functions', () => {
     const asPath = '/imoveis/rj/rio-de-janeiro/apartamento'
     const location = getLocationFromPath(asPath)
     expect(location).toEqual({
-      city: 'rio-de-janeiro',
-      state: 'rj',
+      citySlug: 'rio-de-janeiro',
+      stateSlug: 'rj',
       filters: {
-        citiesSlug: ['rio-de-janeiro'],
+        citySlug: 'rio-de-janeiro',
+        stateSlug: 'rj',
         types: ['Apartamento']
       }
     })

--- a/__tests__/utils/params-mapper/params-mapper.test.js
+++ b/__tests__/utils/params-mapper/params-mapper.test.js
@@ -8,16 +8,17 @@ describe('Parameters Mapper tests', () => {
       () => {
         //simulates => /imoveis/state/city/neighborhood
         const result = ParamsMapper.mapUrlToParams({
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           rest: 'neighborhood'
         })
         const expected = {
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           filters: {
-            citiesSlug: ['city'],
-            neighborhoods: ['neighborhood']
+            citySlug: 'city',
+            neighborhoods: ['neighborhood'],
+            stateSlug: 'state'
           }
         }
         expect(result).toEqual(expected)
@@ -30,15 +31,16 @@ describe('Parameters Mapper tests', () => {
       () => {
         //simulates => /imoveis/state/city/piscina
         const result = ParamsMapper.mapUrlToParams({
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           rest: 'piscina'
         })
         const expected = {
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           filters: {
-            citiesSlug: ['city'],
+            citySlug: 'city',
+            stateSlug: 'state',
             tagsSlug: ['piscina']
           }
         }
@@ -52,15 +54,16 @@ describe('Parameters Mapper tests', () => {
       () => {
         //simulates => /imoveis/state/city/casa
         const result = ParamsMapper.mapUrlToParams({
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           rest: 'casa'
         })
         const expected = {
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           filters: {
-            citiesSlug: ['city'],
+            citySlug: 'city',
+            stateSlug: 'state',
             types: ['Casa']
           }
         }
@@ -74,16 +77,17 @@ describe('Parameters Mapper tests', () => {
       () => {
         //simulates => /imoveis/state/city/neighborhood/piscina
         const result = ParamsMapper.mapUrlToParams({
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           rest: 'neighborhood/piscina'
         })
         const expected = {
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           filters: {
-            citiesSlug: ['city'],
+            citySlug: 'city',
             neighborhoods: ['neighborhood'],
+            stateSlug: 'state',
             tagsSlug: ['piscina']
           }
         }
@@ -96,16 +100,17 @@ describe('Parameters Mapper tests', () => {
       () => {
         //simulates => /imoveis/state/city/neighborhood/casa
         const result = ParamsMapper.mapUrlToParams({
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           rest: 'neighborhood/casa'
         })
         const expected = {
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           filters: {
             types: ['Casa'],
-            citiesSlug: ['city'],
+            citySlug: 'city',
+            stateSlug: 'state',
             neighborhoods: ['neighborhood']
           }
         }
@@ -119,16 +124,17 @@ describe('Parameters Mapper tests', () => {
       () => {
         //simulates => /imoveis/state/city/casa/piscina
         const result = ParamsMapper.mapUrlToParams({
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           rest: 'casa/piscina'
         })
         const expected = {
-          state: 'state',
-          city: 'city',
+          stateSlug: 'state',
+          citySlug: 'city',
           filters: {
             types: ['Casa'],
-            citiesSlug: ['city'],
+            citySlug: 'city',
+            stateSlug: 'state',
             tagsSlug: ['piscina']
           }
         }
@@ -139,16 +145,17 @@ describe('Parameters Mapper tests', () => {
     it('should identify "preco minimo" as a filter', () => {
       //simulates => /imoveis/state/city/preco-min-10000
       const result = ParamsMapper.mapUrlToParams({
-        state: 'state',
-        city: 'city',
+        stateSlug: 'state',
+        citySlug: 'city',
         rest: 'preco-min-10000'
       })
       const expected = {
-        state: 'state',
-        city: 'city',
+        stateSlug: 'state',
+        citySlug: 'city',
         filters: {
           price: {min: 10000},
-          citiesSlug: ['city']
+          citySlug: 'city',
+          stateSlug: 'state'
         }
       }
       expect(result).toEqual(expected)
@@ -157,16 +164,17 @@ describe('Parameters Mapper tests', () => {
     it('should identify "preco minimo" and "preco-maximo" as a filter', () => {
       //simulates => /imoveis/state/city/preco-min-10000
       const result = ParamsMapper.mapUrlToParams({
-        state: 'state',
-        city: 'city',
+        stateSlug: 'state',
+        citySlug: 'city',
         rest: 'preco-min-10000/preco-max-1000000000'
       })
       const expected = {
-        state: 'state',
-        city: 'city',
+        stateSlug: 'state',
+        citySlug: 'city',
         filters: {
           price: {min: 10000, max: 1000000000},
-          citiesSlug: ['city']
+          citySlug: 'city',
+          stateSlug: 'state'
         }
       }
       expect(result).toEqual(expected)
@@ -175,17 +183,18 @@ describe('Parameters Mapper tests', () => {
     it('should identify "quartos" and "preco minimo" and "preco-maximo" as a filter', () => {
       //simulates => /imoveis/state/city/preco-min-10000
       const result = ParamsMapper.mapUrlToParams({
-        state: 'state',
-        city: 'city',
+        stateSlug: 'state',
+        citySlug: 'city',
         rest: '3-quartos/preco-min-10000/preco-max-1000000000'
       })
       const expected = {
-        state: 'state',
-        city: 'city',
+        stateSlug: 'state',
+        citySlug: 'city',
         filters: {
           price: {min: 10000, max: 1000000000},
           rooms: {min: 3, max: 3},
-          citiesSlug: ['city']
+          citySlug: 'city',
+          stateSlug: 'state'
         }
       }
       expect(result).toEqual(expected)
@@ -194,26 +203,16 @@ describe('Parameters Mapper tests', () => {
     it('should return only city and state when rest param is null', () => {
       //simulates => /imoveis/state/city/preco-min-10000
       const result = ParamsMapper.mapUrlToParams({
-        city: 'city',
-        state: 'state'
+        citySlug: 'city',
+        stateSlug: 'state'
       })
       const expected = {
-        state: 'state',
-        city: 'city',
+        stateSlug: 'state',
+        citySlug: 'city',
         filters: {
-          citiesSlug: ['city']
+          citySlug: 'city',
+          stateSlug: 'state'
         }
-      }
-      expect(result).toEqual(expected)
-    })
-
-    it('should return only state when rest and city param is null', () => {
-      //simulates => /imoveis/state/city/preco-min-10000
-      const result = ParamsMapper.mapUrlToParams({
-        state: 'state'
-      })
-      const expected = {
-        state: 'state'
       }
       expect(result).toEqual(expected)
     })
@@ -225,77 +224,80 @@ describe('Parameters Mapper tests', () => {
       expect(result).toEqual(expected)
     })
   })
+
   describe('mapParamsToUrl(params, filters)', () => {
     it('should map filters (state, city, type and ranged price) to path starting with /state/city', () => {
-      const params = {
-        city: 'city',
-        state: 'state'
-      }
       const filters = {
+        citySlug: 'sao-paulo',
+        stateSlug: 'sp',
         types: ['Casa'],
         price: {min: 100000, max: 10000000}
       }
 
-      const result = ParamsMapper.mapParamsToUrl(params, filters)
+      const result = ParamsMapper.mapParamsToUrl(filters)
       expect(result).toEqual(
-        '/state/city/casa/preco-min-100000/preco-max-10000000'
+        '/sp/sao-paulo/casa/preco-min-100000/preco-max-10000000'
       )
     })
 
-    it('should map filters (type and ranged price) to path starting with /busca', () => {
-      const params = {}
+    it('should map filters (type and ranged price) to path starting with /state/city', () => {
       const filters = {
+        citySlug: 'sao-paulo',
+        stateSlug: 'sp',
         types: ['Casa'],
         price: {min: 100000, max: 10000000},
         area: {min: 200, max: 400}
       }
 
-      const result = ParamsMapper.mapParamsToUrl(params, filters)
+      const result = ParamsMapper.mapParamsToUrl(filters)
       expect(result).toEqual(
-        '/busca/casa/preco-min-100000/preco-max-10000000/area-min-200/area-max-400'
+        '/sp/sao-paulo/casa/preco-min-100000/preco-max-10000000/area-min-200/area-max-400'
       )
     })
 
     it(
       'should map filters (type and ranged price - max and min ' +
-        'equals) to path starting with /busca and quartos should contains only value and label',
+        'equals) to path starting with /state/city and quartos should contains only value and label',
       () => {
-        const params = {}
         const filters = {
+          citySlug: 'sao-paulo',
+          stateSlug: 'sp',
           types: ['Casa'],
           rooms: {min: 3, max: 3}
         }
-        const result = ParamsMapper.mapParamsToUrl(params, filters)
-        expect(result).toEqual('/busca/casa/3-quartos')
+        const result = ParamsMapper.mapParamsToUrl(filters)
+        expect(result).toEqual('/sp/sao-paulo/casa/3-quartos')
 
-        const params2 = {}
         const filters2 = {
+          citySlug: 'sao-paulo',
+          stateSlug: 'sp',
           types: ['Casa'],
           garageSpots: {min: 3, max: 3}
         }
-        const result2 = ParamsMapper.mapParamsToUrl(params2, filters2)
-        expect(result2).toEqual('/busca/casa/3-vagas')
+        const result2 = ParamsMapper.mapParamsToUrl(filters2)
+        expect(result2).toEqual('/sp/sao-paulo/casa/3-vagas')
       }
     )
 
     it(
       'should map filters (type and neighborhood) to path ' +
-        'starting with /bairros when no city and state is given',
+        'starting with /state/city',
       () => {
-        const params = {}
         const filters = {
+          citySlug: 'sao-paulo',
+          stateSlug: 'sp',
           types: ['Casa'],
           neighborhoods: ['neighborhoods', 'neighborhoods1'],
           rooms: {min: 3, max: 3}
         }
 
-        let result = ParamsMapper.mapParamsToUrl(params, filters)
+        let result = ParamsMapper.mapParamsToUrl(filters)
         expect(result).toEqual(
-          '/bairros/neighborhoods/neighborhoods1/casa/3-quartos'
+          '/sp/sao-paulo/neighborhoods/neighborhoods1/casa/3-quartos'
         )
         filters.neighborhoods = ['neighborhoods']
-        result = ParamsMapper.mapParamsToUrl(params, filters)
-        expect(result).toEqual('/bairros/neighborhoods/casa/3-quartos')
+        result = ParamsMapper.mapParamsToUrl(filters)
+        expect(result).toEqual('/sp/sao-paulo/neighborhoods/casa/3-quartos')
       }
     )
   })

--- a/components/listings/shared/ListingList/index.js
+++ b/components/listings/shared/ListingList/index.js
@@ -89,8 +89,8 @@ class ListingList extends Component {
                     params.neighborhood && (
                       <Neighborhood
                         neighborhood={params.neighborhood}
-                        state={params.state}
-                        city={params.city}
+                        state={params.stateSlug}
+                        city={params.citySlug}
                         neighborhoodListener={neighborhoodListener}
                       />
                     )

--- a/components/shared/Map/index.js
+++ b/components/shared/Map/index.js
@@ -155,6 +155,9 @@ export default class MapContainer extends Component {
   }
 
   fitMap = (markers) => {
+    if (!this.maps) {
+      return
+    }
     const LatLngList = markers.map((m) => new this.maps.LatLng(m.lat, m.lng))
 
     const bounds = new this.maps.LatLngBounds()
@@ -183,6 +186,9 @@ export default class MapContainer extends Component {
   }
 
   frameMarkers(markers) {
+    if (!this.maps) {
+      return
+    }
     log(LISTING_SEARCH_MAP_CLUSTER)
     const LatLngList = markers.map((m) => new this.maps.LatLng(m.lat, m.lng))
 
@@ -194,6 +200,9 @@ export default class MapContainer extends Component {
   }
 
   resetMapView = () => {
+    if (!this.maps) {
+      return
+    }
     const {mapOptions: {center}} = this.state
     this.map.setCenter(new this.maps.LatLng(center.lat, center.lng))
     this.map.setZoom(13)

--- a/components/shared/NeighborhoodPicker/index.js
+++ b/components/shared/NeighborhoodPicker/index.js
@@ -137,10 +137,6 @@ class NeighborhoodPicker extends Component {
         return
       }
 
-      const neighborhoodPaths = selectedNeighborhoods.join('/')
-      Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}/${neighborhoodPaths}`, {
-        shallow: true
-      })
       const event = new CustomEvent(NEIGHBORHOOD_SELECTION_CHANGE, {
         detail: {
           city: selectedCity,

--- a/components/shared/NeighborhoodPicker/index.js
+++ b/components/shared/NeighborhoodPicker/index.js
@@ -17,6 +17,7 @@ import {GET_DISTRICTS} from 'graphql/listings/queries'
 import {Query} from 'react-apollo'
 import {cities} from 'constants/cities'
 import {arrayToString} from 'utils/text-utils'
+import {isCitySelected} from 'components/shared/NeighborhoodPicker/components/CityContainer/selection'
 import {
   log,
   LISTING_SEARCH_NEIGHBORHOOD_OPEN,
@@ -144,15 +145,21 @@ class NeighborhoodPicker extends Component {
         return
       }
 
+      const allNeighborhoodsSelected = isCitySelected(cities, selectedNeighborhoods, selectedCity.citySlug)
+
       if (this.props.fromHome) {
         const {selectedCity} = this.state
         const neighborhoodsUrl = selectedNeighborhoods.join('/')
-        Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}/${neighborhoodsUrl}`)
+        if (allNeighborhoodsSelected) {
+          Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}`)
+        } else {
+          Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}/${neighborhoodsUrl}`)
+        }
       } else {
         const event = new CustomEvent(NEIGHBORHOOD_SELECTION_CHANGE, {
           detail: {
             city: selectedCity,
-            neighborhoods: selectedNeighborhoods
+            neighborhoods: allNeighborhoodsSelected ? [] : selectedNeighborhoods
           }
         })
         window.dispatchEvent(event)

--- a/components/shared/NeighborhoodPicker/index.js
+++ b/components/shared/NeighborhoodPicker/index.js
@@ -91,7 +91,9 @@ class NeighborhoodPicker extends Component {
   }
 
   applyUserCityFromGeoIp = (userCity) => {
-    this.selectCity(userCity)
+    if (!this.state.selectedCity) {
+      this.selectCity(userCity)
+    }
     if (window.location.pathname !== '/imoveis') {
       return
     }
@@ -120,8 +122,9 @@ class NeighborhoodPicker extends Component {
 
   apply(newSelection) {
     this.changeSelection(newSelection, () => {
+      const {selectedCity, selectedNeighborhoods} = this.state
       log(LISTING_SEARCH_NEIGHBORHOOD_APPLY, {
-        neighborhoods: this.state.selectedNeighborhoods,
+        neighborhoods: selectedNeighborhoods,
         fromHome: this.props.fromHome
       })
       if (this.state.showCities) {
@@ -130,24 +133,21 @@ class NeighborhoodPicker extends Component {
       if (this.props.onBackPressed) {
         this.props.onBackPressed()
       }
-      if (
-        this.props.fromHome &&
-        this.state.selectedNeighborhoods.length === 0
-      ) {
+      if (!selectedCity) {
         return
       }
 
-      if (this.props.fromHome) {
-        const neighborhoodPaths = this.state.selectedNeighborhoods.join('/')
-        Router.push('/listings', `/imoveis/bairros/${neighborhoodPaths}`, {
-          shallow: true
-        })
-      } else {
-        const event = new CustomEvent(NEIGHBORHOOD_SELECTION_CHANGE, {
-          detail: {neighborhoods: this.state.selectedNeighborhoods}
-        })
-        window.dispatchEvent(event)
-      }
+      const neighborhoodPaths = selectedNeighborhoods.join('/')
+      Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}/${neighborhoodPaths}`, {
+        shallow: true
+      })
+      const event = new CustomEvent(NEIGHBORHOOD_SELECTION_CHANGE, {
+        detail: {
+          city: selectedCity,
+          neighborhoods: selectedNeighborhoods
+        }
+      })
+      window.dispatchEvent(event)
     })
   }
 

--- a/components/shared/NeighborhoodPicker/index.js
+++ b/components/shared/NeighborhoodPicker/index.js
@@ -137,13 +137,19 @@ class NeighborhoodPicker extends Component {
         return
       }
 
-      const event = new CustomEvent(NEIGHBORHOOD_SELECTION_CHANGE, {
-        detail: {
-          city: selectedCity,
-          neighborhoods: selectedNeighborhoods
-        }
-      })
-      window.dispatchEvent(event)
+      if (this.props.fromHome) {
+        const {selectedCity} = this.state
+        const neighborhoodsUrl = selectedNeighborhoods.join('/')
+        Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}/${neighborhoodsUrl}`)
+      } else {
+        const event = new CustomEvent(NEIGHBORHOOD_SELECTION_CHANGE, {
+          detail: {
+            city: selectedCity,
+            neighborhoods: selectedNeighborhoods
+          }
+        })
+        window.dispatchEvent(event)
+      }
     })
   }
 

--- a/components/shared/NeighborhoodPicker/index.js
+++ b/components/shared/NeighborhoodPicker/index.js
@@ -91,11 +91,18 @@ class NeighborhoodPicker extends Component {
   }
 
   applyUserCityFromGeoIp = (userCity) => {
+    const {pathname} = location
+    if (pathname !== '/imoveis') {
+      const location = pathname.split('/imoveis/')[1]
+      if (location) {
+        const citySlug = location.split('/')[1]
+        const urlCity = cities.find((city) => city.citySlug === citySlug)
+        this.selectCity(urlCity)
+      }
+      return
+    }
     if (!this.state.selectedCity) {
       this.selectCity(userCity)
-    }
-    if (window.location.pathname !== '/imoveis') {
-      return
     }
     const filterNeighborhoods = userCity.neighborhoods.map((neighborhood) => neighborhood.nameSlug)
     this.apply(filterNeighborhoods)

--- a/pages/listings/index.js
+++ b/pages/listings/index.js
@@ -66,7 +66,13 @@ class ListingSearch extends Component {
       this.setState({filters: newFilters}, () => {
         if (newFilters.neighborhoods) {
           const event = new CustomEvent(NEIGHBORHOOD_SELECTION_CHANGE, {
-            detail: {neighborhoods: newFilters.neighborhoods}
+            detail: {
+              city: {
+                citySlug: newFilters.citySlug,
+                stateSlug: newFilters.stateSlug
+              },
+              neighborhoods: newFilters.neighborhoods
+            }
           })
           window.dispatchEvent(event)
         }
@@ -95,12 +101,13 @@ class ListingSearch extends Component {
     const currentNeighborhoods = this.state.filters.neighborhoods
       ? this.state.filters.neighborhoods.toString()
       : ''
-    const newCity = city ? city.citySlug : ''
-    const currentCity = this.state.citiesSlug && this.state.citiesSlug.length > 0 ? this.state.citiesSlug[0] : ''
-    if (newNeighborhoods !== currentNeighborhoods || newCity !== currentCity) {
-      const newFilters = clone(this.state.filters)
+    const newCitySlug = city ? city.citySlug : ''
+    const currentCitySlug = this.state.citySlug
+    if (newNeighborhoods !== currentNeighborhoods || newCitySlug !== currentCitySlug) {
+      const newFilters = clone(this.state.filters || {})
       newFilters.neighborhoods = neighborhoods
-      newFilters.citiesSlug = [newCity]
+      newFilters.citySlug = city.citySlug
+      newFilters.stateSlug = city.stateSlug
       this.setState(
         {filters: newFilters},
         this.onChangeFilter.bind(this, newFilters)
@@ -109,6 +116,10 @@ class ListingSearch extends Component {
   }
 
   onChangeFilter = (filters) => {
+    const newPath = ParamsMapper.mapParamsToUrl(filters)
+    Router.push('/listings', `/imoveis${newPath}`, {
+      shallow: true
+    })
     this.setState({filters: filters})
     window.scrollTo(0, 0)
   }

--- a/pages/listings/index.js
+++ b/pages/listings/index.js
@@ -147,7 +147,7 @@ class ListingSearch extends Component {
                 <ListingHead
                   districts={districts}
                   filters={filters}
-                  params={params}
+                  params={params || {}}
                   url={url}
                 />
                 <LdJson />
@@ -158,7 +158,7 @@ class ListingSearch extends Component {
                 <ListingList
                   isRoot={isRoot}
                   query={query}
-                  params={params}
+                  params={params || {}}
                   user={user}
                   resetFilters={this.onResetFilter}
                   filters={listingFilters}

--- a/pages/listings/index.js
+++ b/pages/listings/index.js
@@ -87,17 +87,20 @@ class ListingSearch extends Component {
   }
 
   handleNeighborhoodChange = ({detail}) => {
-    // Take action only when neighborhood changes. We do this here because the component
-    // responsible for controlling neighborhood filters is not in the same context as
+    // Take action when neighborhood or city changes. We do this here because the component
+    // responsible for controlling location filters is not in the same context as
     // this ListingSearch or the ListingFilter.
-    const {neighborhoods} = detail
+    const {city, neighborhoods} = detail
     const newNeighborhoods = neighborhoods ? neighborhoods.toString() : ''
     const currentNeighborhoods = this.state.filters.neighborhoods
       ? this.state.filters.neighborhoods.toString()
       : ''
-    if (newNeighborhoods !== currentNeighborhoods) {
+    const newCity = city ? city.citySlug : ''
+    const currentCity = this.state.citiesSlug && this.state.citiesSlug.length > 0 ? this.state.citiesSlug[0] : ''
+    if (newNeighborhoods !== currentNeighborhoods || newCity !== currentCity) {
       const newFilters = clone(this.state.filters)
       newFilters.neighborhoods = neighborhoods
+      newFilters.citiesSlug = [newCity]
       this.setState(
         {filters: newFilters},
         this.onChangeFilter.bind(this, newFilters)
@@ -106,11 +109,6 @@ class ListingSearch extends Component {
   }
 
   onChangeFilter = (filters) => {
-    const newPath = ParamsMapper.mapParamsToUrl(this.props.params, filters)
-    Router.push('/listings', `/imoveis${newPath}`, {
-      shallow: true
-    })
-
     this.setState({filters: filters})
     window.scrollTo(0, 0)
   }

--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -28,19 +28,6 @@ router.get(
     res.locals.app.render(req, res, actualPage, req.query)
   }
 )
-router.get('/busca/:rest([0-9a-z-]*)', (req, res) => {
-  const actualPage = '/listings'
-  const params = ParamsMapper.mapUrlToParams(req.params)
-  req.params = params
-  res.locals.app.render(req, res, actualPage, req.query)
-})
-
-router.get('/bairros/:rest([0-9a-z-]*)', (req, res) => {
-  const actualPage = '/listings'
-  const params = ParamsMapper.mapUrlToParams(req.params)
-  req.params = params
-  res.locals.app.render(req, res, actualPage, req.query)
-})
 
 router.get('/:state/:city/:rest([0-9a-z-]*)', (req, res) => {
   const actualPage = '/listings'

--- a/server/server.js
+++ b/server/server.js
@@ -208,10 +208,6 @@ const startServer = () => {
         return app.render(req, res, '/user/profile', req.query)
       })
 
-      server.get('/busca', (req, res) => {
-        return app.render(req, res, '/search', req.query)
-      })
-
       server.get('/ping', (req, res) => {
         res.status(200).send(`Ping ${new Date() * 1}`)
       })

--- a/utils/filter-params.js
+++ b/utils/filter-params.js
@@ -162,7 +162,7 @@ export const getNewFiltersFromQuery = ({
   const types = tipos && splitParam(tipos).map((type) => (type.value ? type.value : type))
   const neighborhoods = bairros && splitParam(bairros).map((neighborhood) => neighborhood)
   const neighborhoodsSlugs = params && params.neighborhood ? [params.neighborhood] : null
-  const citiesSlug = params && params.city ? [params.city] : null
+  const citySlug = params && params.city ? params.city : null
   const filters = {
     price,
     area,
@@ -171,7 +171,7 @@ export const getNewFiltersFromQuery = ({
     types,
     neighborhoods,
     neighborhoodsSlugs,
-    citiesSlug
+    citySlug
   }
 
   return pickBy(filters, identity)
@@ -228,7 +228,8 @@ export const getListingFiltersFromState = (filterState) => {
     garageSpots,
     rooms,
     neighborhoods,
-    citiesSlug,
+    stateSlug,
+    citySlug,
     tagsSlug,
     types
   } = filterState
@@ -241,7 +242,9 @@ export const getListingFiltersFromState = (filterState) => {
     maxRooms: rooms && parseInt(rooms.max),
     minGarageSpots: garageSpots && parseInt(garageSpots.min),
     maxGarageSpots: garageSpots && parseInt(garageSpots.max),
-    citiesSlug,
+    citySlug,
+    [citySlug ? 'citiesSlug' : undefined]: citySlug ? [citySlug] : undefined,
+    stateSlug,
     tagsSlug,
     types:
       types &&
@@ -262,16 +265,12 @@ export const getListingFiltersFromState = (filterState) => {
  * @param asPath url
  */
 export const getLocationFromPath = (asPath) => {
-  const locationString = asPath.split('?')[0]
+  const locationString = asPath.split('/imoveis/')[1]
   const urlParts = locationString.split('/')
-  const state = urlParts[2]
-  const city = urlParts[3]
+  const state = urlParts[0]
+  const city = urlParts[1]
   let rest = locationString.split(`${state}/${city}/`)[1]
-  if (state === 'bairros' || state === 'search') {
-    rest = locationString.split(`${state}/`)[1] || ''
-    return ParamsMapper.mapUrlToParams({rest})
-  }
-  return ParamsMapper.mapUrlToParams({state, city, rest})
+  return ParamsMapper.mapUrlToParams({stateSlug: state, citySlug: city, rest})
 }
 
 /**

--- a/utils/filter-params.js
+++ b/utils/filter-params.js
@@ -266,11 +266,14 @@ export const getListingFiltersFromState = (filterState) => {
  */
 export const getLocationFromPath = (asPath) => {
   const locationString = asPath.split('/imoveis/')[1]
-  const urlParts = locationString.split('/')
-  const state = urlParts[0]
-  const city = urlParts[1]
-  let rest = locationString.split(`${state}/${city}/`)[1]
-  return ParamsMapper.mapUrlToParams({stateSlug: state, citySlug: city, rest})
+  if (locationString) {
+    const urlParts = locationString.split('/')
+    const state = urlParts[0]
+    const city = urlParts[1]
+    let rest = locationString.split(`${state}/${city}/`)[1]
+    return ParamsMapper.mapUrlToParams({stateSlug: state, citySlug: city, rest})
+  }
+  return ParamsMapper.mapUrlToParams({rest})
 }
 
 /**

--- a/utils/filter-params.js
+++ b/utils/filter-params.js
@@ -273,7 +273,7 @@ export const getLocationFromPath = (asPath) => {
     let rest = locationString.split(`${state}/${city}/`)[1]
     return ParamsMapper.mapUrlToParams({stateSlug: state, citySlug: city, rest})
   }
-  return ParamsMapper.mapUrlToParams({rest})
+  return null
 }
 
 /**

--- a/utils/params-mapper/params-to-url-mapper.js
+++ b/utils/params-mapper/params-to-url-mapper.js
@@ -67,9 +67,8 @@ function mapFiltersToPath(filters = {}) {
   return paths
 }
 
-function mapParamsToUrl(params, filters) {
-  const {state, city} = params
-  const {neighborhoods, tagsSlug, ...filtersRest} = filters
+function mapParamsToUrl(filters) {
+  const {citySlug, stateSlug, neighborhoods, tagsSlug, ...filtersRest} = filters
   const filterPaths = mapFiltersToPath(filtersRest)
   let paths = []
   if (neighborhoods && neighborhoods.length > 0) {
@@ -82,10 +81,7 @@ function mapParamsToUrl(params, filters) {
   }
   paths = paths.concat(filterPaths)
 
-  let startPath = ''
-  if (state && city) {
-    startPath = `/${state}/${city}`
-  }
+  const startPath = `/${stateSlug}/${citySlug}`
   return `${startPath}${paths.join('')}`
 }
 

--- a/utils/params-mapper/params-to-url-mapper.js
+++ b/utils/params-mapper/params-to-url-mapper.js
@@ -82,11 +82,9 @@ function mapParamsToUrl(params, filters) {
   }
   paths = paths.concat(filterPaths)
 
-  let startPath = '/busca'
+  let startPath = ''
   if (state && city) {
     startPath = `/${state}/${city}`
-  } else if (neighborhoods && neighborhoods.length > 0) {
-    startPath = '/bairros'
   }
   return `${startPath}${paths.join('')}`
 }

--- a/utils/params-mapper/url-to-params-mapper.js
+++ b/utils/params-mapper/url-to-params-mapper.js
@@ -204,20 +204,28 @@ const getFiltersByPath = (rest = '') => {
   if (neighborhoods && neighborhoods.length > 0) {
     filters.neighborhoods = neighborhoods
   }
+  const stateAndCity = rest.split('/imoveis/')[1]
+  if (stateAndCity) {
+    const state = stateAndCity.split('/')[0]
+    const city = stateAndCity.split('/')[1]
+    filters.stateSlug = state
+    filters.citySlug = city
+  }
   return filters
 }
 
 const mapUrlToParams = (params) => {
-  const {state, city, rest} = params
+  const {stateSlug, citySlug, rest} = params
   const filters = getFiltersByPath(rest)
   const newParams = {}
-  if (city) {
-    filters.citiesSlug = [city]
-    newParams.city = city
+  if (citySlug) {
+    filters.citySlug = citySlug
+    newParams.citySlug = citySlug
   }
 
-  if (state) {
-    newParams.state = state
+  if (stateSlug) {
+    filters.stateSlug = stateSlug
+    newParams.stateSlug = stateSlug
   }
 
   if (Object.keys(filters).length > 0) {


### PR DESCRIPTION
- [x] Refactor search and update tests.
- [x] Remove `/busca` and `/bairro` from search urls.
- [x] Always start search urls with `/state/city`.
- [x] Redirect to `/state/city` if user selects city from `NeighborhoodPicker` (even if no neighborhoods are selected).
- [x] Fix popstate behavior.
- [x] When every neighborhood from a city is selected, remove them from url and leave only state and city.
- [x] If an url with a neighborhood is open, change the `NeighborhoodPicker` city to that city's neighborhood.