### PR TITLE
Neighborhood Picker and search improvements

### DIFF
--- a/components/listings/shared/ListingList/index.js
+++ b/components/listings/shared/ListingList/index.js
@@ -31,7 +31,10 @@ class ListingList extends Component {
       excludedListingIds: []
     }
   }
-  state = {}
+
+  state = {
+    isFirstLoad: true
+  }
 
   componentWillReceiveProps(newProps) {
     const currentFilters = this.props.filters
@@ -64,7 +67,7 @@ class ListingList extends Component {
       neighborhoodListener
     } = this.props
 
-    if (loading) {
+    if (loading && this.state.isFirstLoad) {
       return this.getLoading()
     }
 
@@ -99,6 +102,7 @@ class ListingList extends Component {
                   filters={filters}
                   remaining_count={result.remainingCount}
                   onLoad={async () => {
+                    this.setState({isFirstLoad: false})
                     const loadedListings = await fetchMore({
                       variables: {
                         pagination: {

--- a/components/shared/NeighborhoodPicker/components/CityContainer/index.js
+++ b/components/shared/NeighborhoodPicker/components/CityContainer/index.js
@@ -120,8 +120,7 @@ class CityContainer extends Component {
       >
         <Row flexDirection="column">
           <Col>
-            <Row flexDirection="row" alignItems="center">
-              {!selectedCity && <Text>Escolha uma cidade</Text>}
+            <Row flexDirection="row" alignItems="center" mt={selectedCity ? 0 : 4}>
               {selectedCity &&
                 <>
                   <Text>{selectedCity.name}</Text>

--- a/components/shared/NeighborhoodPicker/index.js
+++ b/components/shared/NeighborhoodPicker/index.js
@@ -37,7 +37,7 @@ import {
 } from './styles'
 import {NEIGHBORHOOD_SELECTION_CHANGE} from './events'
 
-const DEFAULT_BUTTON_TEXT = 'Escolha os bairros'
+const DEFAULT_BUTTON_TEXT = 'Escolha uma cidade'
 export const DEFAULT_CITY_SLUG = 'sao-paulo'
 export const DEFAULT_CITY = cities.find((city) => city.citySlug === DEFAULT_CITY_SLUG)
 

--- a/components/shared/NeighborhoodPicker/index.js
+++ b/components/shared/NeighborhoodPicker/index.js
@@ -211,9 +211,14 @@ class NeighborhoodPicker extends Component {
 
   getButtonText() {
     if (process.browser) {
-      const selected = this.state.selectedNeighborhoods
-      if (selected && selected.length > 0) {
-        return arrayToString(selected)
+      const {selectedNeighborhoods, selectedCity} = this.state
+      const allNeighborhoodsSelected = selectedCity && isCitySelected(cities, selectedNeighborhoods, selectedCity.citySlug)
+      if (selectedNeighborhoods && selectedNeighborhoods.length > 0 && !allNeighborhoodsSelected) {
+        return arrayToString(selectedNeighborhoods)
+      } else if (!selectedCity) {
+        return DEFAULT_BUTTON_TEXT
+      } else if (selectedCity || allNeighborhoodsSelected) {
+        return selectedCity.name
       }
     }
     return DEFAULT_BUTTON_TEXT

--- a/components/shared/NeighborhoodPicker/index.js
+++ b/components/shared/NeighborhoodPicker/index.js
@@ -100,6 +100,12 @@ class NeighborhoodPicker extends Component {
         const urlCity = cities.find((city) => city.citySlug === citySlug)
         this.selectCity(urlCity)
       }
+      if (pathname === '/') {
+        const cityAutoSelection = cities.find((city) => city.citySlug === userCity.citySlug)
+        if (cityAutoSelection) {
+          this.selectCity(cityAutoSelection)
+        }
+      }
       return
     }
     if (!this.state.selectedCity) {
@@ -150,11 +156,7 @@ class NeighborhoodPicker extends Component {
       if (this.props.fromHome) {
         const {selectedCity} = this.state
         const neighborhoodsUrl = selectedNeighborhoods.join('/')
-        if (allNeighborhoodsSelected) {
-          Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}`)
-        } else {
-          Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}/${neighborhoodsUrl}`)
-        }
+        Router.push('/listings', `/imoveis/${selectedCity.stateSlug}/${selectedCity.citySlug}${!allNeighborhoodsSelected ? `/${neighborhoodsUrl}` : ``}`)
       } else {
         const event = new CustomEvent(NEIGHBORHOOD_SELECTION_CHANGE, {
           detail: {


### PR DESCRIPTION
- [x] Avoid full loading state after first search page load.
- [x] Fix auto city selection in home.
- [x] Show city name in NeighborhoodPicker when a city is selected, or when all neighborhoods of a city are selected.
- [x] Change default NeighborhoodPicker display texts.